### PR TITLE
Add login and signup pages

### DIFF
--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -1,0 +1,9 @@
+import LoginPageComponent from "@/components/pages/login";
+
+export const metadata = {
+  title: "Login - SCG Services Atlanta",
+};
+
+export default function LoginPage() {
+  return <LoginPageComponent />;
+}

--- a/src/app/signup/page.js
+++ b/src/app/signup/page.js
@@ -1,0 +1,9 @@
+import SignupPageComponent from "@/components/pages/signup";
+
+export const metadata = {
+  title: "Sign Up - SCG Services Atlanta",
+};
+
+export default function SignupPage() {
+  return <SignupPageComponent />;
+}

--- a/src/components/navbar/navbar.js
+++ b/src/components/navbar/navbar.js
@@ -124,6 +124,16 @@ export default function Navbar() {
                 About
               </a>
             </li>
+            <li>
+              <a href="/login" className="hover:text-gray-300 transition">
+                Login
+              </a>
+            </li>
+            <li>
+              <a href="/signup" className="hover:text-gray-300 transition">
+                Sign Up
+              </a>
+            </li>
           </ul>
         </div>
       </nav>

--- a/src/components/pages/login.js
+++ b/src/components/pages/login.js
@@ -1,0 +1,55 @@
+"use client";
+import { useState } from "react";
+
+export default function LoginPageComponent() {
+  const [formData, setFormData] = useState({ email: "", password: "" });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log("Login form submitted:", formData);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow p-8 w-full max-w-md">
+        <h1 className="text-2xl font-bold mb-6 text-center">Login</h1>
+        <div className="mb-4">
+          <label htmlFor="email" className="block mb-1">
+            Email
+          </label>
+          <input
+            type="email"
+            id="email"
+            name="email"
+            value={formData.email}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            required
+          />
+        </div>
+        <div className="mb-6">
+          <label htmlFor="password" className="block mb-1">
+            Password
+          </label>
+          <input
+            type="password"
+            id="password"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            required
+          />
+        </div>
+        <button type="submit" className="w-full bg-black text-white py-2 rounded hover:bg-gray-800 transition">
+          Sign In
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/pages/signup.js
+++ b/src/components/pages/signup.js
@@ -1,0 +1,69 @@
+"use client";
+import { useState } from "react";
+
+export default function SignupPageComponent() {
+  const [formData, setFormData] = useState({ name: "", email: "", password: "" });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log("Sign up form submitted:", formData);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow p-8 w-full max-w-md">
+        <h1 className="text-2xl font-bold mb-6 text-center">Sign Up</h1>
+        <div className="mb-4">
+          <label htmlFor="name" className="block mb-1">
+            Name
+          </label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label htmlFor="email" className="block mb-1">
+            Email
+          </label>
+          <input
+            type="email"
+            id="email"
+            name="email"
+            value={formData.email}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            required
+          />
+        </div>
+        <div className="mb-6">
+          <label htmlFor="password" className="block mb-1">
+            Password
+          </label>
+          <input
+            type="password"
+            id="password"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            required
+          />
+        </div>
+        <button type="submit" className="w-full bg-black text-white py-2 rounded hover:bg-gray-800 transition">
+          Create Account
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add login and signup forms under `/login` and `/signup`
- link new pages from the navbar

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d93b10f80832a85c0df03f3222aec