### PR TITLE
Add API calls for login and signup

### DIFF
--- a/src/components/pages/login.js
+++ b/src/components/pages/login.js
@@ -3,15 +3,35 @@ import { useState } from "react";
 
 export default function LoginPageComponent() {
   const [formData, setFormData] = useState({ email: "", password: "" });
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Login form submitted:", formData);
+    try {
+      const response = await fetch(`${apiUrl}/api/auth/local`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          identifier: formData.email,
+          password: formData.password,
+        }),
+      });
+
+      if (!response.ok) throw new Error("Failed to login");
+
+      const data = await response.json();
+      localStorage.setItem("jwt", data.jwt);
+      console.log("Login successful:", data);
+    } catch (error) {
+      console.error("Error logging in:", error);
+    }
   };
 
   return (

--- a/src/components/pages/signup.js
+++ b/src/components/pages/signup.js
@@ -3,15 +3,36 @@ import { useState } from "react";
 
 export default function SignupPageComponent() {
   const [formData, setFormData] = useState({ name: "", email: "", password: "" });
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Sign up form submitted:", formData);
+    try {
+      const response = await fetch(`${apiUrl}/api/auth/local/register`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: formData.name,
+          email: formData.email,
+          password: formData.password,
+        }),
+      });
+
+      if (!response.ok) throw new Error("Failed to sign up");
+
+      const data = await response.json();
+      localStorage.setItem("jwt", data.jwt);
+      console.log("Sign up successful:", data);
+    } catch (error) {
+      console.error("Error signing up:", error);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- implement fetch API requests in login and signup components
- store JWT in localStorage on success

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_684da13dcb40832a9ffd549c0fd64960