### PR TITLE
Add auth context and navbar login state

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -2,6 +2,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Footer from "@/components/footer";
 import WhiteNavbar from "@/components/navbar/navbar";
+import { AuthProvider } from "@/contexts/AuthContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -40,9 +41,11 @@ export default function RootLayout({ children }) {
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <WhiteNavbar></WhiteNavbar>
-        {children}
-        <Footer></Footer>
+        <AuthProvider>
+          <WhiteNavbar />
+          {children}
+          <Footer />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/components/navbar/navbar.js
+++ b/src/components/navbar/navbar.js
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect, useRef } from "react";
+import { useAuth } from "@/contexts/AuthContext";
 import Image from "next/image";
 import Logo from "../../../public/large_logo.svg";
 
@@ -7,6 +8,7 @@ export default function Navbar() {
   const [categories, setCategories] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
+  const { isLoggedIn, logout } = useAuth();
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
   const dropdownRef = useRef(null);
 
@@ -124,16 +126,29 @@ export default function Navbar() {
                 About
               </a>
             </li>
-            <li>
-              <a href="/login" className="hover:text-gray-300 transition">
-                Login
-              </a>
-            </li>
-            <li>
-              <a href="/signup" className="hover:text-gray-300 transition">
-                Sign Up
-              </a>
-            </li>
+            {isLoggedIn ? (
+              <li>
+                <button
+                  onClick={logout}
+                  className="hover:text-gray-300 transition"
+                >
+                  Logout
+                </button>
+              </li>
+            ) : (
+              <>
+                <li>
+                  <a href="/login" className="hover:text-gray-300 transition">
+                    Login
+                  </a>
+                </li>
+                <li>
+                  <a href="/signup" className="hover:text-gray-300 transition">
+                    Sign Up
+                  </a>
+                </li>
+              </>
+            )}
           </ul>
         </div>
       </nav>

--- a/src/components/pages/login.js
+++ b/src/components/pages/login.js
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function LoginPageComponent() {
   const [formData, setFormData] = useState({ email: "", password: "" });
@@ -9,6 +10,7 @@ export default function LoginPageComponent() {
   const [serverMessage, setServerMessage] = useState("");
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
   const router = useRouter();
+  const { login } = useAuth();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -53,7 +55,7 @@ export default function LoginPageComponent() {
       }
 
       const data = await response.json();
-      localStorage.setItem("jwt", data.jwt);
+      login(data.jwt);
       setStatus("success");
       setServerMessage("Login successful!");
       setTimeout(() => router.push("/"), 1500);

--- a/src/components/pages/signup.js
+++ b/src/components/pages/signup.js
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function SignupPageComponent() {
   const [formData, setFormData] = useState({ name: "", email: "", password: "" });
@@ -9,6 +10,7 @@ export default function SignupPageComponent() {
   const [serverMessage, setServerMessage] = useState("");
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
   const router = useRouter();
+  const { login } = useAuth();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -57,10 +59,10 @@ export default function SignupPageComponent() {
       }
 
       const data = await response.json();
-      localStorage.setItem("jwt", data.jwt);
+      login(data.jwt);
       setStatus("success");
       setServerMessage("Account created successfully!");
-      setTimeout(() => router.push("/login"), 1500);
+      setTimeout(() => router.push("/"), 1500);
     } catch (error) {
       console.error("Error signing up:", error);
       setStatus("error");

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,0 +1,40 @@
+"use client";
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+const AuthContext = createContext({
+  isLoggedIn: false,
+  login: () => {},
+  logout: () => {},
+});
+
+export const AuthProvider = ({ children }) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    // Check for stored token on mount
+    const token = localStorage.getItem("jwt");
+    if (token) {
+      setIsLoggedIn(true);
+    }
+  }, []);
+
+  const login = (token) => {
+    if (token) {
+      localStorage.setItem("jwt", token);
+      setIsLoggedIn(true);
+    }
+  };
+
+  const logout = () => {
+    localStorage.removeItem("jwt");
+    setIsLoggedIn(false);
+  };
+
+  return (
+    <AuthContext.Provider value={{ isLoggedIn, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);


### PR DESCRIPTION
## Summary
- add global `AuthContext` to manage login state with JWT from local storage
- wrap layout with `AuthProvider`
- update login and signup pages to use context
- update navbar to show login/sign-up or logout depending on state

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bf9f702c832abe9f03a0fd2af54f